### PR TITLE
[Feature] Github contributions를 직접 가져오도록 기능 추가

### DIFF
--- a/GitTime/Sources/Network/GitTimeCralwerAPI.swift
+++ b/GitTime/Sources/Network/GitTimeCralwerAPI.swift
@@ -13,11 +13,18 @@ enum GitTimeCrawlerAPI {
     case trendingRepositories(language: String?, period: String?)
     case trendingDevelopers(language: String?, period: String?)
     case fetchContributions(userName: String, darkMode: Bool)
+    case fetchContributionsRawdata(userName: String, darkMode: Bool)
 }
 
 extension GitTimeCrawlerAPI: TargetType {
     var baseURL: URL {
-        return URL(string: "https://gittime-crawler.herokuapp.com")!
+        switch self {
+        case .fetchContributionsRawdata(_, _):
+            return URL(string: "https://github.com")!
+        default:
+            return URL(string: "https://gittime-crawler.herokuapp.com")!
+        }
+     
     }
     
     var path: String {
@@ -26,8 +33,10 @@ extension GitTimeCrawlerAPI: TargetType {
             return "/repositories"
         case .trendingDevelopers:
             return "/developers"
-        case .fetchContributions(let userName, _):
+        case let .fetchContributions(userName, _):
             return "/contribution/\(userName)"
+        case let .fetchContributionsRawdata(userName, _):
+            return "/\(userName)"
         }
     }
     
@@ -63,6 +72,9 @@ extension GitTimeCrawlerAPI: TargetType {
         case .fetchContributions(_, let darkMode):
             var params: [String: Any] = [:]
             params["darkMode"] = darkMode
+            return .requestParameters(parameters: params, encoding: URLEncoding.default)
+        case .fetchContributionsRawdata(_, _):
+            let params: [String: Any] = [:]
             return .requestParameters(parameters: params, encoding: URLEncoding.default)
         }
     }

--- a/GitTime/Sources/Services/GitTimeCrawlerService.swift
+++ b/GitTime/Sources/Services/GitTimeCrawlerService.swift
@@ -7,11 +7,13 @@
 //
 
 import RxSwift
+import Moya
 
 protocol GitTimeCrawlerServiceType: class {
     func fetchTrendingRepositories(language: String?, period: String?) -> Observable<[TrendRepo]>
     func fetchTrendingDevelopers(language: String?, period: String?) -> Observable<[TrendDeveloper]>
     func fetchContributions(userName: String) -> Observable<ContributionInfo>
+    func fetchContributionsRawdata(userName: String) -> Observable<Response>
     func fetchTrialContributions() -> Observable<ContributionInfo>
 }
 
@@ -46,6 +48,20 @@ class GitTimeCrawlerService: GitTimeCrawlerServiceType {
                                                            darkMode: isDarkMode))
             .map(ContributionInfo.self)
             .asObservable()
+    }
+    
+    func fetchContributionsRawdata(userName: String) -> Observable<Response> {
+        
+        var isDarkMode = false
+        
+        if #available(iOS 13.0, *) {
+            let style = UIScreen.main.traitCollection.userInterfaceStyle
+            isDarkMode = style == .dark
+        }
+        
+        return self.networking.request(.fetchContributionsRawdata(userName: userName,
+                                                                darkMode: isDarkMode))
+        .asObservable()
     }
     
     func fetchTrialContributions() -> Observable<ContributionInfo> {

--- a/GitTime/Sources/ViewControllers/Activity/ActivityViewReactor.swift
+++ b/GitTime/Sources/ViewControllers/Activity/ActivityViewReactor.swift
@@ -9,6 +9,8 @@
 import ReactorKit
 import RxCocoa
 import RxSwift
+import Moya
+import Kanna
 
 final class ActivityViewReactor: Reactor {
     
@@ -97,13 +99,13 @@ final class ActivityViewReactor: Reactor {
             state.canLoadMore = canLoadMore
             state.page = nextPage
             state.activities = self.activitiesToSectionItem(activities.filter { $0.type != .none })
-//            state.activities = self.activitiesToSectionItem(activities)
+        //            state.activities = self.activitiesToSectionItem(activities)
         case let .fetchActivityMore(activities, nextPage, canLoadMore):
             state.canLoadMore = canLoadMore
             state.page = nextPage
             let sectionItems = state.sectionItems[0].items
                 + self.activitiesToSectionItem(activities.filter { $0.type != .none })
-//                + self.activitiesToSectionItem(activities)
+            //                + self.activitiesToSectionItem(activities)
             state.activities = sectionItems
         }
         return state
@@ -160,10 +162,17 @@ final class ActivityViewReactor: Reactor {
         let startLoading: Observable<Mutation> = .just(.setLoading(true))
         let endLoading: Observable<Mutation> = .just(.setLoading(false))
         
-        let fetchContribution = self.crawlerService.fetchContributions(userName: me.name)
-            .map { contributionInfo -> Mutation in
+        let fetchContribution = self.crawlerService.fetchContributionsRawdata(userName: me.name)
+            .map { response ->  Mutation in
+                let contributionInfo = self.parseContribution(response: response)
                 return .setContributionInfo(contributionInfo)
-            }
+        }
+        .catchError { error -> Observable<ActivityViewReactor.Mutation> in
+            return self.crawlerService.fetchContributions(userName: me.name)
+                .map { contributionInfo -> Mutation in
+                    return .setContributionInfo(contributionInfo)}
+        }
+        
         return .concat([startLoading, fetchContribution, endLoading])
     }
     
@@ -192,7 +201,7 @@ final class ActivityViewReactor: Reactor {
                 let newPage = events.count < ActivityViewReactor.PER_PAGE ? currentPage : currentPage + 1
                 let canLoadMore = events.count == ActivityViewReactor.PER_PAGE
                 return .fetchActivity(events, nextPage: newPage, canLoadMore: canLoadMore)
-            }.catchErrorJustReturn(.fetchActivity([], nextPage: currentPage, canLoadMore: false))
+        }.catchErrorJustReturn(.fetchActivity([], nextPage: currentPage, canLoadMore: false))
         
         return .concat([startLoading, fetchActivity, endLoading])
     }
@@ -213,7 +222,7 @@ final class ActivityViewReactor: Reactor {
                 let newPage = events.count < ActivityViewReactor.PER_PAGE ? currentPage : currentPage + 1
                 let canLoadMore = events.count == ActivityViewReactor.PER_PAGE
                 return .fetchActivityMore(events, nextPage: newPage, canLoadMore: canLoadMore)
-            }.catchErrorJustReturn(.fetchActivityMore([], nextPage: currentPage, canLoadMore: false))
+        }.catchErrorJustReturn(.fetchActivityMore([], nextPage: currentPage, canLoadMore: false))
         
         return .concat([startLoading, fetchActivity, endLoading])
     }
@@ -223,5 +232,45 @@ final class ActivityViewReactor: Reactor {
             .map { events -> Mutation in
                 return .fetchActivityMore(events, nextPage: 1, canLoadMore: false)
         }
+    }
+    
+    private func parseContribution(response: Response) -> ContributionInfo {
+        var contributionCount: Int = 0
+        var contributions: [Contribution] = .init()
+        
+        if let doc = try? HTML(html: response.data, encoding: .utf8) {
+            for rect in doc.css("rect") {
+                if var date = rect["data-date"],
+                    var count = rect["data-count"],
+                    var hexColor = rect["fill"] {
+                    
+                    date = date.replacingOccurrences(of: "\\", with: "")
+                        .replacingOccurrences(of: "/", with: "")
+                        .replacingOccurrences(of: "\"", with: "")
+                    count = count.replacingOccurrences(of: "\\", with: "")
+                        .replacingOccurrences(of: "\"", with: "")
+                    
+                    hexColor = hexColor.replacingOccurrences(of: "\\", with: "")
+                        .replacingOccurrences(of: "\"", with: "")
+                    
+                    contributions.append(Contribution(date: date, contribution: Int(count)!, hexColor: hexColor))
+                }
+            }
+            
+            for count in doc.css("h2, f4 text-normal mb-2") {
+                let decimalCharacters = CharacterSet.decimalDigits
+                let decimalRange = count.text?.rangeOfCharacter(from: decimalCharacters)
+                
+                if decimalRange != nil {
+                    if var countText = count.text {
+                        countText = countText.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+                        contributionCount = Int(countText)!
+                    }
+                }
+            }
+        }
+        
+        return ContributionInfo(count: contributionCount,
+                                contributions: contributions)
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -42,6 +42,7 @@ pod 'Crashlytics'
 pod 'SwiftLint'
 pod 'AcknowList'
 pod 'Bagel'
+pod 'Kanna'
 
 end
 


### PR DESCRIPTION
### What is your PR?  :mag: 

- `CrawlerAPI` 를 통해 `github contributions`를 가져오는 로직이 있습니다. 서버가 깨어있는 경우는 속도가 원할하여 문제 없으나 서버가 잠들어 있는 경우 깨우는데 발생하는 시간이 있기 때문에 해당 기능을 추가하게 되었습니다. 

### Description :memo: 
- `Github Contributions` 가져오기 기능 추가 
  - 해당 기능을 구현함에 있어 다음의 라이브러리를 사용하였습니다. ( `Kanna`) 
  - Github 의 페이지에 직접 접근하여 필요한 정보를 가져옵니다. (HTML Parser 이용) 
  -  Parser에 문제가 있거나 홈페이지 접근이 안되는 경우가 발생하면 기존에 있던 API 로직을 수행하도록 방어 코드를 작성하였습니다. 

### Results :computer: 
| Original With API  |  Parsed data Form Github |
| ------------- | ------------- |
| ![api](https://user-images.githubusercontent.com/45546296/70373818-3a455100-192f-11ea-94dd-465d61d411da.gif)| ![parse](https://user-images.githubusercontent.com/45546296/70373752-8a6fe380-192e-11ea-8138-c49508209b55.gif) |
